### PR TITLE
443

### DIFF
--- a/.ebextensions/sg-ingressfromlb.config
+++ b/.ebextensions/sg-ingressfromlb.config
@@ -4,6 +4,6 @@ Resources:
     Properties:
       GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
       IpProtocol: tcp
-      ToPort: 80
+      ToPort: 443
       FromPort: 443
       SourceSecurityGroupName: {"Fn::GetAtt" : ["AWSEBLoadBalancer" , "SourceSecurityGroup.GroupName"]}


### PR DESCRIPTION
Configuring a security group
If you configure your load balancer to forward traffic to an instance port other than port 80, you must add a rule to your security group that allows inbound traffic over the instance port from your load balancer. If you create your environment in a custom VPC, Elastic Beanstalk adds this rule for you.

You add this rule by adding a Resources key to a configuration file in the .ebextensions directory for your application.

The following example configuration file adds an ingress rule to the AWSEBSecurityGroup security group. This allows traffic on port 1000 from the load balancer's security group.

Example .ebextensions/sg-ingressfromlb.config
```
Resources:
  sslSecurityGroupIngress:
    Type: AWS::EC2::SecurityGroupIngress
    Properties:
      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
      IpProtocol: tcp
      ToPort: 1000
      FromPort: 1000
      SourceSecurityGroupName: {"Fn::GetAtt" : ["AWSEBLoadBalancer" , "SourceSecurityGroup.GroupName"]}
```